### PR TITLE
US86229 - Get the folio image, make background requests optional

### DIFF
--- a/d2l-user-profile-behavior.html
+++ b/d2l-user-profile-behavior.html
@@ -92,33 +92,19 @@
 		},
 		_onFolioResponse: function(response) {
 			if (response.detail.status === 200) {
-				// TODO: Ideally at some point you can get the evidence list filtered by content type
 				var folioResponse = window.D2L.Hypermedia.Siren.Parse(response.detail.xhr.response);
-				var firstEvidenceTile = (folioResponse.getSubEntitiesByClass('evidence') || [ null ])[0];
-				if (firstEvidenceTile) {
-					this._evidenceTileUrl = (firstEvidenceTile.getLinkByRel('self') || {}).href;
-					if (this._evidenceTileUrl) {
-						this._evidenceTileRequest = this._createIronAjaxRequest(this._evidenceTileRequest, this._evidenceTileUrl, this._headers, '_onEvidenceTileResponse');
-						this._evidenceTileRequest.generateRequest();
-					}
+				var tiles = (folioResponse.getSubEntitiesByClass('evidence'));
+				for (var i = 0; i < tiles.length; i++) {
+					var content = tiles[i].getSubEntityByRel(this.HypermediaRels.Folio.contentItem);
+					var type = (content.properties.type || {}).name;
+					if (type === 'Jpg' && type !== 'Png') {
+						this._backgroundUrl = content.properties.url;
+						return;
+					};
 				}
-			} else {
-				// Since the folio request failed, try to get the enrollment image
-				this._makeEnrollmentsRequest();
 			}
-		},
-		_onEvidenceTileResponse: function(response) {
-			if (response.detail.status === 200) {
-				var evidenceTileResponse = window.D2L.Hypermedia.Siren.Parse(response.detail.xhr.response);
-				var content = evidenceTileResponse.getSubEntityByRel(this.HypermediaRels.Folio.contentItem);
 
-				var type = (content.properties.type || {}).name;
-				if (type && type !== 'GoogleDrive' && type !== 'Mp4') {
-					this._backgroundUrl = content.properties.url;
-					return;
-				};
-			}
-			// Since the folio evidence request didn't return an image, try to get the enrollment image
+			// Since the folio request failed, try to get the enrollment image
 			this._makeEnrollmentsRequest();
 		},
 		_onRootResponse: function(response) {

--- a/d2l-user-profile-behavior.html
+++ b/d2l-user-profile-behavior.html
@@ -96,6 +96,13 @@
 				// TODO: Ideally at some point you can get the evidence list filtered by content type
 				var folioResponse = window.D2L.Hypermedia.Siren.Parse(response.detail.xhr.response);
 				var firstEvidenceTile = (folioResponse.getSubEntitiesByClass('evidence') || [])[0];
+				if (firstEvidenceTile) {
+					this._evidenceTileUrl = (firstEvidenceTile.getLinkByRel('self') || {}).href;
+					if (this._evidenceTileUrl) {
+						this._evidenceTileRequest = this._createIronAjaxRequest(this._evidenceTileRequest, this._evidenceTileUrl, this._headers, '_onEvidenceTileResponse');
+						this._evidenceTileRequest.generateRequest();
+					}
+				}
 			} else {
 				// Since the folio request failed, try to get the enrollment image
 				this._makeEnrollmentsRequest();

--- a/d2l-user-profile-behavior.html
+++ b/d2l-user-profile-behavior.html
@@ -78,6 +78,8 @@
 					if (this._folioUrl) {
 						this._folioReqeust = this._createIronAjaxRequest(this._folioReqeust, this._folioUrl, this._headers, '_onFolioResponse');
 						this._folioReqeust.generateRequest();
+					} else {
+						this._makeEnrollmentsRequest();
 					}
 				}
 			}

--- a/d2l-user-profile-behavior.html
+++ b/d2l-user-profile-behavior.html
@@ -95,7 +95,7 @@
 			if (response.detail.status === 200) {
 				// TODO: Ideally at some point you can get the evidence list filtered by content type
 				var folioResponse = window.D2L.Hypermedia.Siren.Parse(response.detail.xhr.response);
-				var firstEvidenceTile = (folioResponse.getSubEntitiesByClass('evidence') || [])[0];
+				var firstEvidenceTile = (folioResponse.getSubEntitiesByClass('evidence') || [ null ])[0];
 				if (firstEvidenceTile) {
 					this._evidenceTileUrl = (firstEvidenceTile.getLinkByRel('self') || {}).href;
 					if (this._evidenceTileUrl) {

--- a/d2l-user-profile-behavior.html
+++ b/d2l-user-profile-behavior.html
@@ -32,10 +32,12 @@
 			this.listen(request, 'iron-ajax-response', onResponse);
 			return request;
 		},
-		generateUserRequest: function(userUrl, token) {
+		generateUserRequest: function(userUrl, token, options) {
 			this._previousUserCall = this._previousUserCall || {};
 			this.userUrl = userUrl || this.userUrl;
-			this.token = token || this.toke;
+			this.token = token || this.token;
+			this.options = options || {};
+
 			if (
 				this.userUrl &&
 				this.token &&
@@ -64,19 +66,54 @@
 						this._iconUrl = (image.getLinkByRel(this.HypermediaRels.thumbnailAlternative) || {}).href;
 					}
 				}
+
 				this._rootUrl = (userResponse.getLinkByRel(this.HypermediaRels.root) || {}).href;
 				if (this._rootUrl) {
 					this._rootReqeust = this._createIronAjaxRequest(this._rootReqeust, this._rootUrl, this._headers, '_onRootResponse');
 					this._rootReqeust.generateRequest();
 				}
 
-				this._enrollmentsUrl = (userResponse.getLinkByRel(this.HypermediaRels.myEnrollments) || {}).href;
-				if (this._enrollmentsUrl) {
-					this._enrollmentsUrl += '?pageSize=2&orgUnitTypeId=3&embedDepth=1';
-					this._enrollmentsRequest = this._createIronAjaxRequest(this._enrollmentsRequest, this._enrollmentsUrl, this._headers, '_onEnrollmentsResponse');
-					this._enrollmentsRequest.generateRequest();
+				if (this.options.background) {
+					this._enrollmentsUrl = (userResponse.getLinkByRel(this.HypermediaRels.myEnrollments) || {}).href;
+					this._folioUrl = (userResponse.getLinkByRel(this.HypermediaRels.Folio.folio) || {}).href;
+					if (this._folioUrl) {
+						this._folioReqeust = this._createIronAjaxRequest(this._folioReqeust, this._folioUrl, this._headers, '_onFolioResponse');
+						this._folioReqeust.generateRequest();
+					}
 				}
 			}
+		},
+		_makeEnrollmentsRequest: function() {
+			// currently only called if we need an image and we can't get one from folio
+			if (this._enrollmentsUrl) {
+				this._enrollmentsUrl += '?pageSize=2&orgUnitTypeId=3&embedDepth=1';
+				this._enrollmentsRequest = this._createIronAjaxRequest(this._enrollmentsRequest, this._enrollmentsUrl, this._headers, '_onEnrollmentsResponse');
+				this._enrollmentsRequest.generateRequest();
+			}
+		},
+		_onFolioResponse: function(response) {
+			if (response.detail.status === 200) {
+				// TODO: Ideally at some point you can get the evidence list filtered by content type
+				var folioResponse = window.D2L.Hypermedia.Siren.Parse(response.detail.xhr.response);
+				var firstEvidenceTile = (folioResponse.getSubEntitiesByClass('evidence') || [])[0];
+			} else {
+				// Since the folio request failed, try to get the enrollment image
+				this._makeEnrollmentsRequest();
+			}
+		},
+		_onEvidenceTileResponse: function(response) {
+			if (response.detail.status === 200) {
+				var evidenceTileResponse = window.D2L.Hypermedia.Siren.Parse(response.detail.xhr.response);
+				var content = evidenceTileResponse.getSubEntityByRel(this.HypermediaRels.Folio.contentItem);
+
+				var type = (content.properties.type || {}).name;
+				if (type && type !== 'GoogleDrive' && type !== 'Mp4') {
+					this._backgroundUrl = content.properties.url;
+					return;
+				};
+			}
+			// Since the folio evidence request didn't return an image, try to get the enrollment image
+			this._makeEnrollmentsRequest();
 		},
 		_onRootResponse: function(response) {
 			if (response.detail.status === 200) {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/14077760/25813713/371e9ba8-33e0-11e7-9b81-4855f979410e.png)

https://rally1.rallydev.com/#/95185052972d/detail/userstory/115774164208?fdp=true

Needs: https://github.com/Brightspace/user-tile/pull/26
Follow testing instructions from: https://github.com/Brightspace/parent-portal-ui/pull/93

**Note:** At the moment this grabs the first folio image in the evidence list and only uses the image if the content of that evidence tile is an image

In order to do this properly, I think that Folio needs to implement a way to filter out non-image evidence entries, so that we can always grab the most recent image one.