### PR TITLE
Reference siren-parser script

### DIFF
--- a/d2l-user-profile-behavior.html
+++ b/d2l-user-profile-behavior.html
@@ -3,6 +3,7 @@
 <link rel="import" href="../d2l-organization-hm-behavior/d2l-organization-hm-behavior.html">
 <link rel="import" href="../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
 
+<script src="https://s.brightspace.com/lib/siren-parser/6.0.0/siren-parser.js"></script>
 <script>
 	'use strict';
 


### PR DESCRIPTION
Generally, not required, since the other things we're using often do this for us. But, it's more correct to reference the script ourselves, so that we don't hit situations where it's undefined.