### PR TITLE
Update d2l-hm-constants-behavior

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "polymer": "^1.7.0",
-    "d2l-hm-constants-behavior": "git://github.com/Brightspace/d2l-hm-constants-behavior.git#^1.0.0",
+    "d2l-hm-constants-behavior": "git://github.com/Brightspace/d2l-hm-constants-behavior.git#^2.0.0",
     "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^1.0.0"
   },
   "devDependencies": {

--- a/d2l-user-profile-behavior.html
+++ b/d2l-user-profile-behavior.html
@@ -211,7 +211,7 @@
 		},
 		_fetchInstitution: function(institutionUrl) {
 			return this._fetchSirenEntity(institutionUrl).then(function(institutionEntity) {
-				var themeUrl = (institutionEntity.getLinkByRel(this.HypermediaRels.theme) || {}).href;
+				var themeUrl = (institutionEntity.getLinkByRel(this.HypermediaRels.Themes.theme) || {}).href;
 				return Promise.resolve(themeUrl);
 			}.bind(this));
 		},


### PR DESCRIPTION
This update contains a small breaking change - moving the theme rels into their own namespace - which caused problems down the line. Solution: use the newer version of d2l-hm-constants-behavior.