### PR TITLE
Update to latest hm consts

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "polymer": "^1.7.0",
-    "d2l-hm-constants-behavior": "git://github.com/Brightspace/d2l-hm-constants-behavior.git#^2.0.0",
+    "d2l-hm-constants-behavior": "git://github.com/Brightspace/d2l-hm-constants-behavior.git#^3.0.0",
     "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This repo should not be impacted by the breaking changes introduced in hm-constants 3.0.0 (grades/notifications).