### PR TITLE
Switch back to the old major version of d2l-organization-hm-behavior

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "polymer": "^1.7.0",
     "d2l-hm-constants-behavior": "git://github.com/Brightspace/d2l-hm-constants-behavior.git#^3.0.0",
-    "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^2.0.0"
+    "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^1.0.0"
   },
   "devDependencies": {
     "web-component-tester": "^6.0.0"

--- a/d2l-user-profile-behavior.html
+++ b/d2l-user-profile-behavior.html
@@ -237,7 +237,7 @@
 	* @polymerBehavior window.D2L.UserProfileBehavior
 	*/
 	window.D2L.UserProfileBehavior = [
-		D2L.PolymerBehaviors.Hypermedia.OrganizationHMBehavior,
+		window.D2L.Hypermedia.OrganizationHMBehavior,
 		window.D2L.Hypermedia.HMConstantsBehavior,
 		window.D2L.UserProfileBehaviorImpl
 	];


### PR DESCRIPTION
Using the new version of `d2l-organization-hm-behavior` causes some issues with other components that use this, switching back for now until the effort is available to fix those as well.

I left all the linting and testing improvements from https://github.com/Brightspace/user-profile-behavior/pull/18 in though.