### PR TITLE
Use siren-parser-import

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "polymer": "^1.7.0",
     "d2l-hm-constants-behavior": "git://github.com/Brightspace/d2l-hm-constants-behavior.git#^3.0.0",
-    "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^1.0.0"
+    "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^1.0.0",
+    "siren-parser-import": "Brightspace/siren-parser-import#^7.0.0"
   },
   "devDependencies": {
     "web-component-tester": "^6.0.0"

--- a/d2l-user-profile-behavior.html
+++ b/d2l-user-profile-behavior.html
@@ -1,8 +1,8 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-organization-hm-behavior/d2l-organization-hm-behavior.html">
 <link rel="import" href="../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
+<link rel="import" href="../siren-parser-import/siren-parser.html">
 
-<script src="https://s.brightspace.com/lib/siren-parser/6.0.0/siren-parser.js"></script>
 <script>
 	/* @polymerBehavior window.D2L.UserProfileBehavior */
 	window.D2L.UserProfileBehaviorImpl = {

--- a/test/consumer-element.html
+++ b/test/consumer-element.html
@@ -1,6 +1,5 @@
 <link rel="import" href="../d2l-user-profile-behavior.html">
 
-<script src="https://s.brightspace.com/lib/siren-parser/6.0.0/siren-parser.js"></script>
 <script src="https://s.brightspace.com/lib/d2lfetch/1.0.0/d2lfetch.js"></script>
 
 <dom-module id="consumer-element">


### PR DESCRIPTION
This allows for correct versioning of the script to avoid nasty surprises about which version is actually being fetched. Also removed direct reference to the CDN script in a test that wasn't needed.